### PR TITLE
fix: SSR error now shows a no internet connection alert when client disconnects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tcp-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@headlessui/react": "^1.7.18",
         "next": "14.0.4",
         "react": "^18",
         "react-dom": "^18",
@@ -841,6 +842,22 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.18",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
+      "integrity": "sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==",
+      "dependencies": {
+        "@tanstack/react-virtual": "^3.0.0-beta.60",
+        "client-only": "^0.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
@@ -1560,6 +1577,31 @@
       "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.2.tgz",
+      "integrity": "sha512-9XbRLPKgnhMwwmuQMnJMv+5a9sitGNCSEtf/AZXzmJdesYk7XsjYHaEDny+IrJzvPNwZliIIDwCRiaUqR3zzCA==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0.tgz",
+      "integrity": "sha512-SYXOBTjJb05rXa2vl55TTwO40A6wKu0R5i1qQwhJYNDIqaIGF7D0HsLw+pJAyi2OvntlEIVusx3xtbbgSUi6zg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@headlessui/react": "^1.7.18",
     "next": "14.0.4",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/(pages)/layout.tsx
+++ b/src/app/(pages)/layout.tsx
@@ -19,6 +19,7 @@ export default function PageLayout({
     <html lang="en">
       <body>
         <Header />
+        <div id="top-page-alert"/>
         <PageHeader />
         {children}
       </body>

--- a/src/app/(pages)/transit/error.tsx
+++ b/src/app/(pages)/transit/error.tsx
@@ -1,4 +1,4 @@
-'use client' // Error components must be Client Components
+'use client';
  
 import { useEffect } from 'react'
 import TransitHeader from './component/TransitHeader'
@@ -6,16 +6,16 @@ import { BiError } from "react-icons/bi";
  
 export default function Error({
   error,
-  reset,
+  _,
 }: {
   error: Error & { digest?: string }
-  reset: () => void
+  _: () => void
 }) {
   useEffect(() => {
     // Log the error to an error reporting service
     console.error(error)
   }, [error])
-
+  
   return (
     <div className="mx-4 mt-10">
       <TransitHeader />

--- a/src/app/(pages)/transit/page.tsx
+++ b/src/app/(pages)/transit/page.tsx
@@ -45,17 +45,13 @@ const fetchTransitData = async () => {
     return { data, error: null };
   } catch (error) {
     console.error("error fetching transit data: ", error);
-    return { data: null, error: true };
+    throw new Error("error fetching transit data");
   }
 };
 
 // should display a refresh button with an outlined border. It should call the revalidateTransitData() function
 const Page = async () => {
   const transitData = await fetchTransitData();
-
-  if (transitData.error) {
-    throw new Error();
-  }
   
   return (
     <div className="mx-4 mt-10">

--- a/src/app/component/HeaderInfo.tsx
+++ b/src/app/component/HeaderInfo.tsx
@@ -6,7 +6,7 @@ const HeaderInfo = () => {
   return (
     <div
       data-testid="headerInfo"
-      className="flex my-2 py-3 border-b border-stone-400 relative border-t border-t-gray-200"
+      className="flex mt-2 py-3 border-b border-stone-400 relative border-t border-t-gray-200"
     >
       <Alert />
       <div

--- a/src/app/component/InternetConnectionAlert.tsx
+++ b/src/app/component/InternetConnectionAlert.tsx
@@ -1,0 +1,32 @@
+"use client";
+import React from "react";
+import { Transition } from '@headlessui/react'
+import { BiError } from "react-icons/bi";
+
+export default function InternetConnectionAlert({ showAlert }: { showAlert: boolean }) {
+  
+  return (
+    <div 
+      className={`bg-red-500 transition-[padding] duration-700 ease-in-out relative ${showAlert ? "pb-[45px]" : "pb-0"}`}
+    >
+      <Transition 
+        show={showAlert}
+        appear
+        unmount={false}
+        enter="delay-500 transition duration-100 ease-out"
+        enterFrom="transform scale-95 opacity-0"
+        enterTo="transform scale-100 opacity-100"
+        leave="transition duration-75 ease-out"
+        leaveFrom="transform scale-100 opacity-100"
+        leaveTo="transform scale-95 opacity-0"
+      >
+        <div 
+          className="absolute w-full flex flex-row bg-red-500 items-center justify-center text-white py-2"
+        >
+          <BiError className="w-[25px] h-[25px] mr-2"/>
+          <p className="text-center">No internet connection</p>
+        </div>
+      </Transition>
+    </div>
+  );
+}

--- a/src/app/component/Revalidator.tsx
+++ b/src/app/component/Revalidator.tsx
@@ -1,26 +1,35 @@
 "use client";
 import React, { useEffect } from "react";
+import { createPortal } from "react-dom";
+import InternetConnectionAlert from "./InternetConnectionAlert";
 
 type RevalidatorHOCProps = {
   revalidateFuncion: () => void;
   children: React.ReactNode;
 }
 function RevalidatorHOC({ revalidateFuncion, children }: RevalidatorHOCProps) {
+  const [DOMloaded, setDOMloaded] = React.useState(false);
+  const [showAlert, setShowAlert] = React.useState(false);
+  
   useEffect(() => {
+    if(!DOMloaded) setDOMloaded(true);
+
     const updateViews = async () => {
-      await revalidateFuncion();
+      if(window.navigator.onLine) {        
+        setShowAlert(false);
+        await revalidateFuncion();
+      } else {
+        console.error("no internet connection");
+        setShowAlert(true);
+      }
     }
 
     const min = 60;
     const refreshWindow = (1 / 2) * min;
     const interval = refreshWindow * 1000; //1000 is the constant
     const intervalId = setInterval(updateViews, interval);
-    try{
-      updateViews();
-    } catch (e) {
-      debugger
-      console.log("failed to revalidate", e)
-    }
+    
+    updateViews();
 
     // Cleanup to clear interval when component unmounts
     return () => {
@@ -29,7 +38,13 @@ function RevalidatorHOC({ revalidateFuncion, children }: RevalidatorHOCProps) {
   }, []);
 
   return (
-    <>{children}</>
+    <>
+      {children}
+      {DOMloaded && createPortal(
+        <InternetConnectionAlert showAlert={showAlert} />, 
+        document.getElementById("top-page-alert") as HTMLElement
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## What's New

- Using the `window.navigator.onLine` method mentioned in Stack overflow ([Link](https://stackoverflow.com/questions/57383593/skipping-fetch-if-network-offline-with-if-statement)) to check if the browser is connected to the internet
- Added a headless UI framework for TailwindCSS ([Package](https://headlessui.com/react/transition#component-api)) for transitions. We can use this for forms, etc
- Using React's `createPortal` ([React Docs](https://react.dev/reference/react-dom/createPortal)) to push the alert to the top of the page from other components.


This should stop the application error from rendering