### PR TITLE
fix(no-cache): removing cache on transit api calls. 

### DIFF
--- a/src/app/(pages)/page.tsx
+++ b/src/app/(pages)/page.tsx
@@ -26,7 +26,7 @@ const fetchTransitData = async () => {
     ];
 
     const responses = await Promise.all(
-      urls.map(url => fetch(url, { next: { tags: ['transit-data'] }}))
+      urls.map(url => fetch(url, { next: { tags: ['transit-data'] }, cache: 'no-store' }))
     );
     const data = await Promise.all(responses.map(response => response.json()));
 


### PR DESCRIPTION
When refreshing, users would get outdated values for a quick flash, and then the new values would come in.