### PR TITLE
fix(cache-flash): next.js revalidation of cache flash

### DIFF
--- a/src/app/(pages)/component/transit/TransitPage.tsx
+++ b/src/app/(pages)/component/transit/TransitPage.tsx
@@ -14,11 +14,14 @@ const TransitPage = ({ _transitData }: { _transitData: TransitDataType}) => {
 
   useEffect(() => {
     if(!DOMloaded) setDOMloaded(true);
+  }, []);
+  
+  useEffect(() => {
     const fetchData = async (): Promise<TransitDataType> => {
       try {
         const response = await fetch(
           "/api/getTransitData",
-          { next: { revalidate: 30 } }
+          { cache: "no-store" }
         );
         const responseData = await response.json();
 
@@ -37,9 +40,9 @@ const TransitPage = ({ _transitData }: { _transitData: TransitDataType}) => {
     const intervalId = setInterval(() => {
       fetchData().then((data: TransitDataType) => {
         if(window.navigator.onLine) {
-          setShowAlert(() => false);
+          if(showAlert) setShowAlert(() => false);
         } else {
-          setShowAlert(() => true);
+          if(!showAlert) setShowAlert(() => true);
         }
 
         if(data.data === null) return setShowAlert(() => true);
@@ -47,12 +50,12 @@ const TransitPage = ({ _transitData }: { _transitData: TransitDataType}) => {
         if(showAlert) setShowAlert(() => false);
         setTransitData(data);
       });
-    }, 3000);
+    }, showAlert ? 3000 : 30000);
 
     return () => {
       clearInterval(intervalId);
     };
-  }, []);
+  }, [showAlert]);
 
   return (
     <ul>

--- a/src/app/utils/transit.test.ts
+++ b/src/app/utils/transit.test.ts
@@ -31,7 +31,7 @@ describe('fetchTransitData', () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(urls.length);
     urls.forEach((url) => {
-      expect(global.fetch).toHaveBeenCalledWith(url, { next: { revalidate: 30 } });
+      expect(global.fetch).toHaveBeenCalledWith(url, { cache: 'no-store' });
     });
     expect(promiseAllSpy).toHaveBeenCalledTimes(2);
     expect(result).toEqual({ data: [{ some: 'data' }, { some: 'data' }, { some: 'data' }], error: null });

--- a/src/app/utils/transit.ts
+++ b/src/app/utils/transit.ts
@@ -7,7 +7,7 @@ export const fetchTransitData = async () => {
     ];
 
     const responses = await Promise.all(
-      urls.map(url => fetch(url, { next: { revalidate: 30 } }))
+      urls.map(url => fetch(url, { cache: "no-store" }))
     );
     const data = await Promise.all(responses.map(response => response.json()));
 


### PR DESCRIPTION
## What's new

- Current approach is having caching issues, where if the user has visiter the app before and they visit again, it renders the last stored times shortly (for ~3 seconds), then it updates to the actual current values.
- New Approach fixes this by
  - removing nextjs cache. The way nextjs revalidates cache does not fit the transit app behavior. 
  - Split the `useEffect()` logic, where it now depends on the `showAlert` state to dynamically change the polling interval. When the user is connected and everything works, the nextjs app fetches our transit API every `30` seconds. As soon as that call fails, the interval changes to every `3` seconds. 
  - The reason for 3 seconds is the same as before. It allows the user to see the alert for a few seconds and then the alert goes away.


## testing

- comment out [Lines 26-27](https://github.com/TheCitizensProject/tcp-frontend-nextjs/blob/cache-flash/src/app/layout.tsx#L26-L27) on `layout.tsx`
- Run `nvm use && npm run build` 
- run `npm run start`
- Let the app fetch a few times
- stop the front end process running the app
- verify that the `Reconnecting...` alert shows up
- Start the next.js app again `npm run start`
- verify that the alert goes away